### PR TITLE
Add original price with line-through style to indicate sale prices

### DIFF
--- a/frontend/src/components/All/All.module.css
+++ b/frontend/src/components/All/All.module.css
@@ -25,3 +25,8 @@
 .beerLink:hover {
   text-decoration: underline;
 }
+
+.originalPrice {
+  text-decoration: line-through;
+  color: #868686;
+}

--- a/frontend/src/components/All/All.tsx
+++ b/frontend/src/components/All/All.tsx
@@ -145,8 +145,13 @@ const All: React.FC = () => {
       },
       {
         header: 'Price',
-        accessorKey: 'main_price',
-        Cell: ({ cell }) => <span>${cell.getValue<number>().toFixed(2)}</span>,
+        accessorFn: (row) => {
+          if (row.original_price === -1) {
+            return <span>${row.main_price.toFixed(2)}</span>
+          } else {
+            return <span><div className={styles.originalPrice}>${row.original_price.toFixed(2)}</div>${row.main_price.toFixed(2)}</span>
+          }
+        },
         maxSize: 50,
       },
       {

--- a/frontend/src/components/Value/Value.module.css
+++ b/frontend/src/components/Value/Value.module.css
@@ -31,5 +31,9 @@
   font-family: "Roboto", sans-serif;
   text-align: center;
   margin: 50px 0px 120px 0px;
+}
 
+.originalPrice {
+  text-decoration: line-through;
+  color: #868686;
 }

--- a/frontend/src/components/Value/Value.tsx
+++ b/frontend/src/components/Value/Value.tsx
@@ -213,8 +213,13 @@ const Value: React.FC = () => {
       },
       {
         header: 'Price',
-        accessorKey: 'main_price',
-        Cell: ({ cell }) => <span>${cell.getValue<number>().toFixed(2)}</span>,
+        accessorFn: (row) => {
+          if (row.original_price === -1) {
+            return <span>${row.main_price.toFixed(2)}</span>
+          } else {
+            return <span><div className={styles.originalPrice}>${row.original_price.toFixed(2)}</div>${row.main_price.toFixed(2)}</span>
+          }
+        },
         maxSize: 50,
         enableSorting: false,
       },


### PR DESCRIPTION
This change lets the user see the original price of a beer when it is on sale. Previously, the site would only show the sale price. Now both the sale price and the original price will be displayed.