### PR TITLE
fix: improve beer filter X button usability

### DIFF
--- a/components/all/BeerCombobox.tsx
+++ b/components/all/BeerCombobox.tsx
@@ -74,7 +74,7 @@ export default function BeerCombobox({
               {name}
               <button
                 onClick={() => remove(name)}
-                className="hover:text-amber-600 leading-none"
+                className="hover:text-amber-600 leading-none cursor-pointer px-1 -mx-1 text-base"
                 aria-label={`Remove ${name}`}
               >
                 ×


### PR DESCRIPTION
## Summary
- Larger click target with horizontal padding (`px-1 -mx-1`)
- Bigger × character (`text-base` instead of inherited `text-xs`)
- `cursor-pointer` so hover shows it's clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)